### PR TITLE
Migrate currencylayer and alphavantage to new format

### DIFF
--- a/price-server/config/default-sample.js
+++ b/price-server/config/default-sample.js
@@ -623,5 +623,21 @@ module.exports = {
       interval: 30 * 1000,
       timeout: 5000,
     },
+    currencylayer: {
+      symbols: fiatSymbols,
+      interval: 60 * 1000,
+      timeout: 5000,
+      // https://currencylayer.com/product
+      // recommend: business subscription(60second Updates): $79.99/month
+      apiKey: '', // necessary
+    },
+    alphavantage: {
+      symbols: fiatSymbols,
+      interval: 60 * 1000,
+      timeout: 5000,
+      // https://www.alphavantage.co/premium/
+      // recommend: 120 API request per minute: $49.99/month
+      apiKey: '', // necessary
+    },
   },
 }

--- a/price-server/src/provider/fiat/quoter/AlphaVantage.ts
+++ b/price-server/src/provider/fiat/quoter/AlphaVantage.ts
@@ -32,7 +32,8 @@ export class AlphaVantage extends Quoter {
       throw new Error('Invalid response from AlphaVantage')
     }
 
-    this.setPrice(symbol, num(response['Realtime Currency Exchange Rate']['5. Exchange Rate']))
+    const convertedPrice = num(1).dividedBy(num(response['Realtime Currency Exchange Rate']['5. Exchange Rate']))
+    this.setPrice(symbol, convertedPrice)
   }
 
   protected async update(): Promise<boolean> {

--- a/price-server/src/provider/fiat/quoter/CurrencyLayer.ts
+++ b/price-server/src/provider/fiat/quoter/CurrencyLayer.ts
@@ -30,8 +30,10 @@ export class CurrencyLayer extends Quoter {
 
     // update last trades
     for (const symbol of Object.keys(response.quotes)) {
-      const convertedSymbol = symbol.replace('USD', 'USD/')
-      this.setPrice(convertedSymbol === 'USD/XDR' ? 'USD/SDR' : convertedSymbol, num(response.quotes[symbol]))
+      const convertedSymbol = symbol.replace('USD', '') + '/USD'
+      const convertedPrice = num(1).dividedBy(num(response.quotes[symbol]))
+
+      this.setPrice(convertedSymbol === 'XDR/USD' ? 'SDR/USD' : convertedSymbol, convertedPrice)
     }
   }
 

--- a/price-server/src/provider/fiat/quoter/CurrencyLayer.ts
+++ b/price-server/src/provider/fiat/quoter/CurrencyLayer.ts
@@ -16,7 +16,7 @@ export class CurrencyLayer extends Quoter {
     const params = {
       access_key: this.options.apiKey,
       source: 'USD',
-      currencies: this.symbols.map((symbol) => (symbol === 'USD/SDR' ? 'XDR' : symbol.replace('USD/', ''))).join(','),
+      currencies: this.symbols.map((symbol) => (symbol === 'SDR/USD' ? 'XDR' : symbol.replace('/USD', ''))).join(','),
     }
 
     const response: Response = await fetch(`https://apilayer.net/api/live?${toQueryString(params)}`, {


### PR DESCRIPTION
These 2 paid providers update latest price every 60 secs, we should use them.
Free ones like exchangerate update price once in 24 hrs, which is not ideal.