### PR TITLE
Fix typo in default-sample.js

### DIFF
--- a/price-server/config/default-sample.js
+++ b/price-server/config/default-sample.js
@@ -629,7 +629,7 @@ module.exports = {
       symbols: fiatSymbols,
       interval: 60 * 1000,
       timeout: 5000,
-      apikey: '', // necessary
+      apiKey: '', // necessary
     },
     // https://currencylayer.com/product
     // recommend: Enterprise (60second Updates): $59.99/month


### PR DESCRIPTION
It is referred as `apiKey` in code