### PR TITLE
fix: feeder entrypoint.sh querying wrong oracle endpoint

### DIFF
--- a/feeder/entrypoint.sh
+++ b/feeder/entrypoint.sh
@@ -5,7 +5,7 @@ npm start add-key
 # check if voter has been bound to validator
 voter_addr=$(jq -r '.[0].address' voter.json)
 lcd=$(echo $ORACLE_FEEDER_LCD_ADDRESS | awk -F"," '{print $1}')
-feeder=$(curl "$lcd/oracle/voters/$ORACLE_FEEDER_VALIDATORS/feeder" | jq -r '.result')
+feeder=$(curl "$lcd/terra/oracle/v1beta1/validators/$ORACLE_FEEDER_VALIDATORS/feeder" | jq -r '.feeder_addr')
 
 if [ $voter_addr != $feeder ]; then
     echo "WRONG FEEDER. REGISTER IT THROUGH: terrad tx oracle set-feeder $voter_addr --from=<validator>"


### PR DESCRIPTION
Dear L1 team. It seems the API of the oracle LCD requests has changed in the new release on `rebel-2`. This is why the feeder is not able to query the correct feeder account from the blockchain. Adjusted `entrypoint.sh` in `feeder` accordingly.
I humbly ask to accept these changes. This PR should be editable by maintainers - so you are free to add whats missing.