### PR TITLE
fix: missing `isClassic` argument in `tx.toData()`

### DIFF
--- a/feeder/src/vote.ts
+++ b/feeder/src/vote.ts
@@ -209,7 +209,7 @@ export async function processVote(
   })
 
   const res = await client.tx.broadcastBlock(tx).catch((err) => {
-    logger.error(`broadcast error: ${err.message} ${tx.toData()}`)
+    logger.error(`broadcast error: ${err.message} ${tx.toData(client.isClassic)}`)
     throw err
   })
 


### PR DESCRIPTION
The missing `isClassic` flag leads to the tx method `toData()` interpreting the tx as message as if it were a phoenix-1 msg. This panics - because on phoenix-1 oracle messages are not supported. This error inhibits the actual broadcast error message (which would be otherwise pretty useful to have in the logs).