### PR TITLE
fix: MsgAggregateExchangeRatePrevote error

### DIFF
--- a/feeder/src/vote.ts
+++ b/feeder/src/vote.ts
@@ -209,7 +209,7 @@ export async function processVote(
   })
 
   const res = await client.tx.broadcastBlock(tx).catch((err) => {
-    logger.error(`broadcast error: ${err.message} ${tx.toData()}`)
+    logger.error(`broadcast error: ${err.message} ${tx.toData(client.config.isClassic)}`)
     throw err
   })
 


### PR DESCRIPTION
```
[INFO][Fri, 29 Sep 2023 05:22:43 GMT] [VOTE] Requesting on chain data
[INFO][Fri, 29 Sep 2023 05:22:44 GMT] [VOTE] Requesting prices from price server http://oracle-price-server:8532/latest
[INFO][Fri, 29 Sep 2023 05:22:44 GMT] [VOTE] Create transaction and sign
[INFO][Fri, 29 Sep 2023 05:22:44 GMT] [PREVOTE] msg: ["{\"@type\":\xxxxxxx


[ERROR][Fri, 29 Sep 2023 05:22:44 GMT] Error: Not supported for the network
    at MsgAggregateExchangeRatePrevote.toData (/app/node_modules/@terra-money/terra.js/src/core/oracle/msgs/MsgAggregateExchangeRatePrevote.ts:71:13)
    at /app/node_modules/@terra-money/terra.js/src/core/Tx.ts:185:42
    at Array.map (<anonymous>)
    at TxBody.toData (/app/node_modules/@terra-money/terra.js/src/core/Tx.ts:185:31)
    at Tx.toData (/app/node_modules/@terra-money/terra.js/src/core/Tx.ts:59:23)
    at /app/src/vote.ts:212:56
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async processVote (/app/src/vote.ts:211:15)
    at async vote (/app/src/vote.ts:333:5)
```